### PR TITLE
Bugfix/fixed srm button disappearing

### DIFF
--- a/SongRequestManager/SongRequestManager.csproj
+++ b/SongRequestManager/SongRequestManager.csproj
@@ -7,7 +7,7 @@
 		<LangVersion>8</LangVersion>
 		<Nullable>enable</Nullable>
 		<OutDir>$(ProjectDir)bin\$(Configuration)</OutDir>
-		<ModVersion>0.6.3</ModVersion>
+		<ModVersion>0.6.4</ModVersion>
 		<AssemblyVersion>$(ModVersion)</AssemblyVersion>
 		<FileVersion>$(ModVersion)</FileVersion>
 		<InformationalVersion>$(ModVersion)</InformationalVersion>

--- a/SongRequestManager/UI/SongRequestsButtonViewController.cs
+++ b/SongRequestManager/UI/SongRequestsButtonViewController.cs
@@ -54,9 +54,8 @@ namespace SongRequestManager.UI
 		public void Start()
 		{
 			Logger.Log("SRMBUTTON init invoked");
-			var standardLevel = _standardLevelDetailViewController;
 			BSMLParser.instance.Parse(BeatSaberMarkupLanguage.Utilities.GetResourceContent(Assembly.GetExecutingAssembly(), "SongRequestManager.UI.Views.SongRequestsButtonView.bsml"),
-				standardLevel.transform.Find("LevelDetail").gameObject, this);
+				_standardLevelDetailViewController.gameObject, this);
 			_srmButtonTransform.localScale *= 0.7f; //no scale property in bsml as of now so manually scaling it
 
 			_songQueueService.RequestQueue.CollectionChanged += OnRequestQueueChanged;

--- a/SongRequestManager/UI/Views/SongRequestsButtonView.bsml
+++ b/SongRequestManager/UI/Views/SongRequestsButtonView.bsml
@@ -1,5 +1,5 @@
 <bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-	xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
+	xsi:noNamespaceSchemaLocation='https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
 
 	<button
 		id='srm-button'
@@ -7,7 +7,7 @@
 		glow-color='~glowy-color'
 		interactable='~interactable'
 		anchor-pos-x='28'
-		anchor-pos-y='66'
+		anchor-pos-y='-6'
 		pref-width='18'
 		pref-height='8'
 		word-wrapping='false'

--- a/SongRequestManager/manifest.json
+++ b/SongRequestManager/manifest.json
@@ -5,7 +5,7 @@
 	"description": "Let your viewers request songs by using chat commands.",
 	"author": "Eris",
 	"gameVersion": "1.11.0",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"dependsOn": {
 		"BeatSaberMarkupLanguage": "^1.3.4",
 		"BeatSaverSharp": "^1.6.0",


### PR DESCRIPTION
Due to the previous implementation of the SRM button, it would disappear from the view whenever the songDetail was loading or refresh.
This PR fixes that by moving it up the parentnode in viewtree (which happens to make it slightly more performant because it has to do less logic for that)