### PR TITLE
bugfix/Change max song duration default value

### DIFF
--- a/SongRequestManager/Settings/Partial/FilterSettings.cs
+++ b/SongRequestManager/Settings/Partial/FilterSettings.cs
@@ -8,7 +8,7 @@ namespace SongRequestManager.Settings.Partial
 		public const int MAX_SONG_DURATION_UPPER_LIMIT = 999;
 
 		public virtual int MinimumRating { get; set; } = 0;
-		public virtual int MaximumSongDuration { get; set; } = 0;
+		public virtual int MaximumSongDuration { get; set; } = 1000;
 		public virtual int MinimumNjs { get; set; } = 0;
 	}
 }

--- a/SongRequestManager/SongRequestManager.csproj
+++ b/SongRequestManager/SongRequestManager.csproj
@@ -7,7 +7,7 @@
 		<LangVersion>8</LangVersion>
 		<Nullable>enable</Nullable>
 		<OutDir>$(ProjectDir)bin\$(Configuration)</OutDir>
-		<ModVersion>0.6.4</ModVersion>
+		<ModVersion>0.6.5</ModVersion>
 		<AssemblyVersion>$(ModVersion)</AssemblyVersion>
 		<FileVersion>$(ModVersion)</FileVersion>
 		<InformationalVersion>$(ModVersion)</InformationalVersion>

--- a/SongRequestManager/manifest.json
+++ b/SongRequestManager/manifest.json
@@ -5,7 +5,7 @@
 	"description": "Let your viewers request songs by using chat commands.",
 	"author": "Eris",
 	"gameVersion": "1.11.0",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"dependsOn": {
 		"BeatSaberMarkupLanguage": "^1.3.4",
 		"BeatSaverSharp": "^1.6.0",


### PR DESCRIPTION
The value for max song duration for songs was on 0 by default, this prevented anyone from doing requests out-of-the-box.
This PR changes the default value to "unlimited" instead.